### PR TITLE
BOOKING-289: Moved cache entry creation into message handler to enabl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 See [keep a changelog](https://keepachangelog.com/en/1.0.0/) for information about writing changes to this log.
 
-## [develop]
+## [Unreleased]
 
 ### Added
 
@@ -16,6 +16,7 @@ See [keep a changelog](https://keepachangelog.com/en/1.0.0/) for information abo
 - Added API for fetching cached user bookings.
 - Removed Rabbit MQ (remeber to update the DSN in local .env)
 - Updated docker compose setup to newest version
+- Fixed issue with booking cache entries not being created.
 
 ## [1.1.2] - 2023-08-29
 

--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,7 @@
             "./vendor/bin/psalm --no-cache --alter --issues=MissingReturnType,MissingParamType --dry-run"
         ],
         "queues": [
-            "bin/console messenger:consume async --failure-limit=1 -vvv"
+            "bin/console messenger:consume async --failure-limit=5 -vvv"
         ],
         "tests": [
             "bin/console --env=test doctrine:database:drop --if-exists --force --quiet",

--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,7 @@
             "./vendor/bin/psalm --no-cache --alter --issues=MissingReturnType,MissingParamType --dry-run"
         ],
         "queues": [
-            "bin/console messenger:consume async --failure-limit=5 -vvv"
+            "bin/console messenger:consume async --failure-limit=1 -vvv"
         ],
         "tests": [
             "bin/console --env=test doctrine:database:drop --if-exists --force --quiet",

--- a/src/Message/AddBookingToCacheMessage.php
+++ b/src/Message/AddBookingToCacheMessage.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Message;
+
+use App\Entity\Main\Booking;
+
+class AddBookingToCacheMessage
+{
+    public function __construct(private readonly Booking $booking, private readonly string $iCalUID)
+    {
+    }
+
+    public function getBooking(): Booking
+    {
+        return $this->booking;
+    }
+
+    public function getICalUID(): string
+    {
+        return $this->iCalUID;
+    }
+}

--- a/src/MessageHandler/AddBookingToCacheHandler.php
+++ b/src/MessageHandler/AddBookingToCacheHandler.php
@@ -42,9 +42,8 @@ class AddBookingToCacheHandler
                 'status' => 'AWAITING_APPROVAL',
                 'resourceMail' => $booking->getResourceEmail(),
             ]);
-        }
-        else {
-            throw new RecoverableMessageHandlingException(sprintf("Booking id could not be retrieved for booking with iCalUID: %s", $message->getICalUID()));
+        } else {
+            throw new RecoverableMessageHandlingException(sprintf('Booking id could not be retrieved for booking with iCalUID: %s', $message->getICalUID()));
         }
     }
 }

--- a/src/MessageHandler/AddBookingToCacheHandler.php
+++ b/src/MessageHandler/AddBookingToCacheHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Message\AddBookingToCacheMessage;
+use App\Service\BookingServiceInterface;
+use App\Service\UserBookingCacheServiceInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
+
+/**
+ * @see https://github.com/itk-dev/os2forms_selvbetjening/blob/develop/web/modules/custom/os2forms_rest_api/README.md
+ */
+#[AsMessageHandler]
+class AddBookingToCacheHandler
+{
+    public function __construct(
+        private readonly BookingServiceInterface $bookingService,
+        private readonly UserBookingCacheServiceInterface $userBookingCacheService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function __invoke(AddBookingToCacheMessage $message): void
+    {
+        $this->logger->info('AddBookingToCacheHandler invoked.');
+
+        $booking = $message->getBooking();
+        $id = $this->bookingService->getBookingIdFromICalUid($message->getICalUID()) ?? null;
+
+        if (null != $id) {
+            $this->userBookingCacheService->addCacheEntryFromArray([
+                'subject' => $booking->getSubject(),
+                'id' => $id,
+                'body' => $booking->getBody(),
+                'start' => $booking->getStartTime(),
+                'end' => $booking->getEndTime(),
+                'status' => 'AWAITING_APPROVAL',
+                'resourceMail' => $booking->getResourceEmail(),
+            ]);
+        }
+        else {
+            throw new RecoverableMessageHandlingException(sprintf("Booking id could not be retrieved for booking with iCalUID: %s", $message->getICalUID()));
+        }
+    }
+}

--- a/src/MessageHandler/CreateBookingHandler.php
+++ b/src/MessageHandler/CreateBookingHandler.php
@@ -119,7 +119,7 @@ class CreateBookingHandler
                     $response['iCalUId'],
                 ));
             } else {
-                $this->logger->error(sprintf("Booking iCalUID could not be retrieved for booking with subject: %s", $booking->getSubject()));
+                $this->logger->error(sprintf('Booking iCalUID could not be retrieved for booking with subject: %s', $booking->getSubject()));
             }
         } catch (BookingCreateConflictException $exception) {
             // If it is a BookingCreateConflictException the booking should be rejected.

--- a/tests/Api/BookingTest.php
+++ b/tests/Api/BookingTest.php
@@ -16,7 +16,6 @@ use App\Security\Voter\BookingVoter;
 use App\Service\BookingServiceInterface;
 use App\Service\MicrosoftGraphBookingService;
 use App\Service\NotificationServiceInterface;
-use App\Service\UserBookingCacheServiceInterface;
 use App\Service\WebformService;
 use App\Tests\AbstractBaseApiTestCase;
 use App\Utils\ValidationUtils;

--- a/tests/Api/BookingTest.php
+++ b/tests/Api/BookingTest.php
@@ -7,6 +7,7 @@ use App\Entity\Main\Booking;
 use App\Entity\Resources\AAKResource;
 use App\Message\CreateBookingMessage;
 use App\Message\WebformSubmitMessage;
+use App\MessageHandler\AddBookingToCacheHandler;
 use App\MessageHandler\CreateBookingHandler;
 use App\MessageHandler\WebformSubmitHandler;
 use App\Repository\Resources\AAKResourceRepository;
@@ -216,13 +217,11 @@ class BookingTest extends AbstractBaseApiTestCase
     {
         $microsoftGraphServiceMock = $this->getMockBuilder(MicrosoftGraphBookingService::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['createBookingForResource', 'getBookingIdFromICalUid'])
+            ->onlyMethods(['createBookingForResource'])
             ->getMock();
         $microsoftGraphServiceMock->expects($this->exactly(1))->method('createBookingForResource')->willReturn([
             'iCalUId' => '12345',
         ]);
-
-        $microsoftGraphServiceMock->expects($this->exactly(1))->method('getBookingIdFromICalUid')->willReturn('12345');
 
         $container = self::getContainer();
         $logger = $container->get(LoggerInterface::class);
@@ -276,13 +275,19 @@ class BookingTest extends AbstractBaseApiTestCase
 
         $container->set(AAKResourceRepository::class, $aakResourceRepositoryMock);
 
+        $addBookingToCacheHandlerMock = $this->getMockBuilder(AddBookingToCacheHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['__invoke'])
+            ->getMock();
+        $addBookingToCacheHandlerMock->expects($this->exactly(1))->method('__invoke');
+        $container->set(AddBookingToCacheHandler::class, $addBookingToCacheHandlerMock);
+
         $notificationServiceMock = $this->createMock(NotificationServiceInterface::class);
         $container->set(NotificationServiceInterface::class, $notificationServiceMock);
 
         $cvrWhitelistRepositoryMock = $this->createMock(CvrWhitelistRepository::class);
 
-        $userBookingCacheService = $container->get(UserBookingCacheServiceInterface::class);
-        $createBookingHandler = new CreateBookingHandler($microsoftGraphServiceMock, $logger, $aakResourceRepositoryMock, $security, $bus, $cvrWhitelistRepositoryMock, $userBookingCacheService);
+        $createBookingHandler = new CreateBookingHandler($microsoftGraphServiceMock, $logger, $aakResourceRepositoryMock, $security, $bus, $cvrWhitelistRepositoryMock);
         $createBookingHandler->__invoke(new CreateBookingMessage($booking));
     }
 

--- a/tests/Api/BookingTest.php
+++ b/tests/Api/BookingTest.php
@@ -76,7 +76,7 @@ class BookingTest extends AbstractBaseApiTestCase
 
     public function testBookingWebform(): void
     {
-        $this->messenger('async')->queue()->assertEmpty();
+        $this->transport('async')->queue()->assertEmpty();
 
         $client = $this->getAuthenticatedClient();
 
@@ -102,15 +102,15 @@ class BookingTest extends AbstractBaseApiTestCase
         $this->assertResponseStatusCodeSame(201);
 
         /** @var WebformSubmitMessage $message */
-        $message = $this->messenger('async')->queue()->first(WebformSubmitMessage::class)->getMessage();
+        $message = $this->transport('async')->queue()->first(WebformSubmitMessage::class)->getMessage();
         $this->assertEquals('booking', $message->getWebformId());
         $this->assertEquals('795f5a1c-a0ac-4f8a-8834-bb71fca8585d', $message->getSubmissionUuid());
         $this->assertEquals('https://bookaarhus.local.itkdev.dk', $message->getSender());
         $this->assertEquals('https://bookaarhus.local.itkdev.dk/webform_rest/booking/submission/123123123', $message->getSubmissionUrl());
         $this->assertEquals(1, $message->getApiKeyUserId());
 
-        $this->messenger('async')->queue()->assertCount(1);
-        $this->messenger('async')->queue()->assertContains(WebformSubmitMessage::class);
+        $this->transport('async')->queue()->assertCount(1);
+        $this->transport('async')->queue()->assertContains(WebformSubmitMessage::class);
     }
 
     /**
@@ -118,7 +118,7 @@ class BookingTest extends AbstractBaseApiTestCase
      */
     public function testWebformSubmitMessageHandler(): void
     {
-        $this->messenger('async')->queue()->assertEmpty();
+        $this->transport('async')->queue()->assertEmpty();
 
         $webformServiceMock = $this->getMockBuilder(WebformService::class)
             ->onlyMethods(['getWebformSubmission', 'getData'])
@@ -208,8 +208,8 @@ class BookingTest extends AbstractBaseApiTestCase
             $testUser->getId()
         ));
 
-        $this->messenger('async')->queue()->assertContains(CreateBookingMessage::class);
-        $this->messenger('async')->queue()->assertCount(1);
+        $this->transport('async')->queue()->assertContains(CreateBookingMessage::class);
+        $this->transport('async')->queue()->assertCount(1);
     }
 
     public function testCreateBookingHandler(): void
@@ -288,7 +288,7 @@ class BookingTest extends AbstractBaseApiTestCase
 
     public function testInvalidBookingWebform(): void
     {
-        $this->messenger('async')->queue()->assertEmpty();
+        $this->transport('async')->queue()->assertEmpty();
 
         $client = $this->getAuthenticatedClient();
 
@@ -309,6 +309,6 @@ class BookingTest extends AbstractBaseApiTestCase
 
         $this->assertResponseStatusCodeSame(400);
 
-        $this->messenger('async')->queue()->assertCount(0);
+        $this->transport('async')->queue()->assertCount(0);
     }
 }

--- a/tests/Handler/AddBookingToCacheHandlerTest.php
+++ b/tests/Handler/AddBookingToCacheHandlerTest.php
@@ -2,31 +2,14 @@
 
 namespace App\Tests\Handler;
 
-use App\Entity\Main\ApiKeyUser;
 use App\Entity\Main\Booking;
-use App\Entity\Resources\AAKResource;
 use App\Message\AddBookingToCacheMessage;
-use App\Message\CreateBookingMessage;
-use App\Message\WebformSubmitMessage;
 use App\MessageHandler\AddBookingToCacheHandler;
-use App\MessageHandler\CreateBookingHandler;
-use App\MessageHandler\WebformSubmitHandler;
-use App\Repository\Resources\AAKResourceRepository;
-use App\Repository\Resources\CvrWhitelistRepository;
 use App\Security\Voter\BookingVoter;
 use App\Service\BookingServiceInterface;
-use App\Service\MicrosoftGraphBookingService;
-use App\Service\NotificationServiceInterface;
 use App\Service\UserBookingCacheServiceInterface;
-use App\Service\WebformService;
 use App\Tests\AbstractBaseApiTestCase;
-use App\Utils\ValidationUtils;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Security\Core\Security;
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
-use Twig\Environment;
-use Zenstruck\Messenger\Test\InteractsWithMessenger;
 
 class AddBookingToCacheHandlerTest extends AbstractBaseApiTestCase
 {
@@ -35,7 +18,7 @@ class AddBookingToCacheHandlerTest extends AbstractBaseApiTestCase
         $bookingServiceMock = $this->getMockBuilder(BookingServiceInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $bookingServiceMock->expects($this->exactly(1))->method('getBookingIdFromICalUid')->willReturn("abcde");
+        $bookingServiceMock->expects($this->exactly(1))->method('getBookingIdFromICalUid')->willReturn('abcde');
 
         $userBookingCacheServiceMock = $this->getMockBuilder(UserBookingCacheServiceInterface::class)
             ->disableOriginalConstructor()
@@ -71,7 +54,7 @@ class AddBookingToCacheHandlerTest extends AbstractBaseApiTestCase
 
         $message = new AddBookingToCacheMessage(
             $booking,
-            "12345"
+            '12345'
         );
 
         $handler->__invoke($message);

--- a/tests/Handler/AddBookingToCacheHandlerTest.php
+++ b/tests/Handler/AddBookingToCacheHandlerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Tests\Handler;
+
+use App\Entity\Main\ApiKeyUser;
+use App\Entity\Main\Booking;
+use App\Entity\Resources\AAKResource;
+use App\Message\AddBookingToCacheMessage;
+use App\Message\CreateBookingMessage;
+use App\Message\WebformSubmitMessage;
+use App\MessageHandler\AddBookingToCacheHandler;
+use App\MessageHandler\CreateBookingHandler;
+use App\MessageHandler\WebformSubmitHandler;
+use App\Repository\Resources\AAKResourceRepository;
+use App\Repository\Resources\CvrWhitelistRepository;
+use App\Security\Voter\BookingVoter;
+use App\Service\BookingServiceInterface;
+use App\Service\MicrosoftGraphBookingService;
+use App\Service\NotificationServiceInterface;
+use App\Service\UserBookingCacheServiceInterface;
+use App\Service\WebformService;
+use App\Tests\AbstractBaseApiTestCase;
+use App\Utils\ValidationUtils;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Twig\Environment;
+use Zenstruck\Messenger\Test\InteractsWithMessenger;
+
+class AddBookingToCacheHandlerTest extends AbstractBaseApiTestCase
+{
+    public function testHandlerVoter(): void
+    {
+        $bookingServiceMock = $this->getMockBuilder(BookingServiceInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $bookingServiceMock->expects($this->exactly(1))->method('getBookingIdFromICalUid')->willReturn("abcde");
+
+        $userBookingCacheServiceMock = $this->getMockBuilder(UserBookingCacheServiceInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $userBookingCacheServiceMock->expects($this->exactly(1))->method('addCacheEntryFromArray');
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+
+        $handler = new AddBookingToCacheHandler(
+            $bookingServiceMock,
+            $userBookingCacheServiceMock,
+            $loggerMock,
+        );
+
+        $booking = new Booking();
+        $booking->setBody('test');
+        $booking->setSubject('test');
+        $booking->setResourceName('test');
+        $booking->setResourceEmail('test@bookaarhus.local.itkdev.dk');
+        $booking->setStartTime(new \DateTime());
+        $booking->setEndTime(new \DateTime());
+        $booking->setUserName('author1');
+        $booking->setUserMail('author1@bookaarhus.local.itkdev.dk');
+        $booking->setMetaData([
+            'meta_data_4' => '1, 2, 3',
+            'meta_data_5' => 'a1, b2, c3',
+            'meta_data_1' => 'This is a metadata field',
+            'meta_data_2' => 'This is also metadata',
+            'meta_data_3' => 'Lorem ipsum metadata',
+        ]);
+        $booking->setUserPermission(BookingVoter::PERMISSION_CITIZEN);
+        $booking->setUserId('1234567890');
+
+        $message = new AddBookingToCacheMessage(
+            $booking,
+            "12345"
+        );
+
+        $handler->__invoke($message);
+    }
+}


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/BOOKING-289

#### Description

Moved cache entry creation into message handler to enable retry strategies.

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.
