### PR TITLE
Hotfix/date time zone

### DIFF
--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -31,9 +31,6 @@ class NotificationService implements NotificationServiceInterface
 {
     private ?string $validatedAdminNotificationEmail;
 
-    /**
-     * @param non-empty-string $bindNotificationTimezone
-     */
     public function __construct(
         private readonly string $emailFromAddress,
         private readonly string $emailAdminNotification,
@@ -103,8 +100,13 @@ class NotificationService implements NotificationServiceInterface
         $dateStart = $userBooking->start;
         $dateEnd = $userBooking->end;
 
-        $dateStart->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
-        $dateEnd->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
+        if (!empty($this->bindNotificationTimezone)) {
+            $dateStart->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
+            $dateEnd->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
+        } else {
+            // Handle the case where bindNotificationTimezone is empty
+            throw new \InvalidArgumentException('bindNotificationTimezone cannot be empty');
+        }
 
         $resourceName = $resource?->getResourceDisplayName() ?? $userBooking->displayName;
 
@@ -185,8 +187,13 @@ class NotificationService implements NotificationServiceInterface
         $event->setDescription($eventData['description']);
         $event->setLocation($location);
 
-        $dateFrom = $eventData['start']->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
-        $dateTo = $eventData['end']->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
+        if (!empty($this->bindNotificationTimezone)) {
+            $dateFrom = $eventData['start']->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
+            $dateTo = $eventData['end']->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
+        } else {
+            // Handle the case where bindNotificationTimezone is empty
+            throw new \InvalidArgumentException('bindNotificationTimezone cannot be empty');
+        }
 
         $start = new ICalDateTime($dateFrom, true);
         $end = new ICalDateTime($dateTo, true);
@@ -219,6 +226,14 @@ class NotificationService implements NotificationServiceInterface
             if (null !== $booking) {
                 $dateStart = $booking->getStartTime();
                 $dateEnd = $booking->getEndTime();
+
+                if (!empty($this->bindNotificationTimezone)) {
+                    $dateStart->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
+                    $dateEnd->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
+                } else {
+                    // Handle the case where bindNotificationTimezone is empty
+                    throw new \InvalidArgumentException('bindNotificationTimezone cannot be empty');
+                }
 
                 $dateStart->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
                 $dateEnd->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
@@ -300,9 +315,14 @@ class NotificationService implements NotificationServiceInterface
 
             $dateStart = $booking->getStartTime();
             $dateEnd = $booking->getEndTime();
-
-            $dateStart->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
-            $dateEnd->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
+            if (!empty($this->bindNotificationTimezone)) {
+                $dateStart->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
+                $dateEnd->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
+            } else {
+                // Handle the case where bindNotificationTimezone is empty
+                // For example, you can throw an exception or set a default timezone
+                throw new \InvalidArgumentException('bindNotificationTimezone cannot be empty');
+            }
 
             $data['startFormatted'] = $dateStart->format($this->bindNotificationDateFormat);
             $data['endFormatted'] = $dateEnd->format($this->bindNotificationDateFormat);

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -31,6 +31,9 @@ class NotificationService implements NotificationServiceInterface
 {
     private ?string $validatedAdminNotificationEmail;
 
+    /**
+     * @param non-empty-string $bindNotificationTimezone
+     */
     public function __construct(
         private readonly string $emailFromAddress,
         private readonly string $emailAdminNotification,
@@ -46,6 +49,10 @@ class NotificationService implements NotificationServiceInterface
             );
         } catch (\Exception $exception) {
             $this->logger->warning('No admin notification email set.');
+        }
+
+        if (!$this->bindNotificationTimezone) {
+            throw new \InvalidArgumentException('bindNotificationTimezone cannot be empty');
         }
     }
 
@@ -100,13 +107,8 @@ class NotificationService implements NotificationServiceInterface
         $dateStart = $userBooking->start;
         $dateEnd = $userBooking->end;
 
-        if (!empty($this->bindNotificationTimezone)) {
-            $dateStart->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
-            $dateEnd->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
-        } else {
-            // Handle the case where bindNotificationTimezone is empty
-            throw new \InvalidArgumentException('bindNotificationTimezone cannot be empty');
-        }
+        $dateStart->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
+        $dateEnd->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
 
         $resourceName = $resource?->getResourceDisplayName() ?? $userBooking->displayName;
 
@@ -187,13 +189,8 @@ class NotificationService implements NotificationServiceInterface
         $event->setDescription($eventData['description']);
         $event->setLocation($location);
 
-        if (!empty($this->bindNotificationTimezone)) {
-            $dateFrom = $eventData['start']->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
-            $dateTo = $eventData['end']->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
-        } else {
-            // Handle the case where bindNotificationTimezone is empty
-            throw new \InvalidArgumentException('bindNotificationTimezone cannot be empty');
-        }
+        $dateFrom = $eventData['start']->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
+        $dateTo = $eventData['end']->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
 
         $start = new ICalDateTime($dateFrom, true);
         $end = new ICalDateTime($dateTo, true);
@@ -227,13 +224,8 @@ class NotificationService implements NotificationServiceInterface
                 $dateStart = $booking->getStartTime();
                 $dateEnd = $booking->getEndTime();
 
-                if (!empty($this->bindNotificationTimezone)) {
-                    $dateStart->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
-                    $dateEnd->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
-                } else {
-                    // Handle the case where bindNotificationTimezone is empty
-                    throw new \InvalidArgumentException('bindNotificationTimezone cannot be empty');
-                }
+                $dateStart->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
+                $dateEnd->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
 
                 $dateStartString = $dateStart->format($this->bindNotificationDateFormat);
                 $dateEndString = $dateEnd->format($this->bindNotificationDateFormat);
@@ -312,13 +304,9 @@ class NotificationService implements NotificationServiceInterface
 
             $dateStart = $booking->getStartTime();
             $dateEnd = $booking->getEndTime();
-            if (!empty($this->bindNotificationTimezone)) {
-                $dateStart->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
-                $dateEnd->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
-            } else {
-                // Handle the case where bindNotificationTimezone is empty
-                throw new \InvalidArgumentException('bindNotificationTimezone cannot be empty');
-            }
+
+            $dateStart->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
+            $dateEnd->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
 
             $data['startFormatted'] = $dateStart->format($this->bindNotificationDateFormat);
             $data['endFormatted'] = $dateEnd->format($this->bindNotificationDateFormat);

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -235,9 +235,6 @@ class NotificationService implements NotificationServiceInterface
                     throw new \InvalidArgumentException('bindNotificationTimezone cannot be empty');
                 }
 
-                $dateStart->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
-                $dateEnd->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
-
                 $dateStartString = $dateStart->format($this->bindNotificationDateFormat);
                 $dateEndString = $dateEnd->format($this->bindNotificationDateFormat);
             }
@@ -320,7 +317,6 @@ class NotificationService implements NotificationServiceInterface
                 $dateEnd->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));
             } else {
                 // Handle the case where bindNotificationTimezone is empty
-                // For example, you can throw an exception or set a default timezone
                 throw new \InvalidArgumentException('bindNotificationTimezone cannot be empty');
             }
 


### PR DESCRIPTION
#### Link to ticket

[Please add a link to the ticket being addressed by this change.](https://leantime.itkdev.dk/dashboard/home#/tickets/showTicket/2047)

#### Description

While testing, this error emerged. 

ERROR: ArgumentTypeCoercion - src/Service/NotificationService.php:320:55 - Argument 1 of DateTimeZone::__construct expects non-empty-string, but parent type string provided (see https://psalm.dev/193)
            $dateEnd->setTimezone(new PhpDateTimeZone($this->bindNotificationTimezone));

could be fixed with, but this would ignore the test.

* @param non-empty-string $bindNotificationTimezone

		 

Used if statement on all failing error statements instead.
#### Screenshot of the result
#### Checklist

- [x ] My code is covered by test cases.
- [ x] My code passes our test (all our tests).
- [ x] My code passes our static analysis suite.
- [ x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
