### PR TITLE
Feature/4050 remove misleading null default from cache entity

### DIFF
--- a/src/Controller/CancelBookingController.php
+++ b/src/Controller/CancelBookingController.php
@@ -71,7 +71,7 @@ class CancelBookingController extends AbstractController
                     $result['status'] = CancelBookingStatusEnum::FORBIDDEN->value;
                 } else {
                     $this->bookingService->deleteBooking($userBooking);
-                    $this->userBookingCacheService->deleteCacheEntryByICalUId($id);
+                    $this->userBookingCacheService->deleteCacheEntryByICalUId($iCalUID);
 
                     $result['status'] = CancelBookingStatusEnum::DELETED->value;
                 }

--- a/src/Controller/CreateBookingController.php
+++ b/src/Controller/CreateBookingController.php
@@ -183,7 +183,7 @@ class CreateBookingController extends AbstractController
                             // Delete booking
                             $this->bookingService->deleteBookingByICalUid($iCalUId);
                             // Remove from cache
-                            $this->userBookingCacheService->deleteCacheEntry($iCalUId);
+                            $this->userBookingCacheService->deleteCacheEntryByICalUId($iCalUId);
 
                             $bookingRequest->status = CreateBookingStatusEnum::CANCELLED;
                         } catch (\Throwable) {

--- a/src/Entity/Main/ApiKeyUser.php
+++ b/src/Entity/Main/ApiKeyUser.php
@@ -15,7 +15,7 @@ class ApiKeyUser implements UserInterface
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    private int $id;
+    private ?int $id;
 
     #[ORM\Column(type: 'string', length: 255, unique: true)]
     #[Assert\Length(
@@ -32,7 +32,7 @@ class ApiKeyUser implements UserInterface
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     private ?string $webformApiKey;
 
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/src/Entity/Main/ApiKeyUser.php
+++ b/src/Entity/Main/ApiKeyUser.php
@@ -15,7 +15,7 @@ class ApiKeyUser implements UserInterface
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    private ?int $id;
+    private int $id;
 
     #[ORM\Column(type: 'string', length: 255, unique: true)]
     #[Assert\Length(
@@ -32,7 +32,7 @@ class ApiKeyUser implements UserInterface
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     private ?string $webformApiKey;
 
-    public function getId(): ?int
+    public function getId(): int
     {
         return $this->id;
     }

--- a/src/Entity/Main/UserBookingCacheEntry.php
+++ b/src/Entity/Main/UserBookingCacheEntry.php
@@ -89,50 +89,50 @@ class UserBookingCacheEntry
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
-    private ?int $id = null;
+    private int $id;
 
     #[Groups('userBookingCacheEntry')]
     #[ORM\Column(length: 255)]
-    private ?string $title = null;
+    private string $title;
 
     // TODO: Remove Groups. ExchangeId should not be used in the frontend.
     #[Groups('userBookingCacheEntry')]
     #[ORM\Column(length: 255)]
-    private ?string $exchangeId = null;
+    private string $exchangeId;
 
     #[ORM\Column(length: 255)]
-    private ?string $uid = null;
+    private string $uid;
 
     #[Groups('userBookingCacheEntry')]
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private ?\DateTimeInterface $start = null;
+    private \DateTimeInterface $start;
 
     #[Groups('userBookingCacheEntry')]
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private ?\DateTimeInterface $end = null;
+    private \DateTimeInterface $end;
 
     #[Groups('userBookingCacheEntry')]
     #[ORM\Column(length: 255)]
-    private ?string $status = null;
+    private string $status;
 
     #[Groups('userBookingCacheEntry')]
     #[ORM\Column(length: 255)]
-    private ?string $resourceMail = null;
+    private string $resourceMail;
 
     #[Groups('userBookingCacheEntry')]
     #[ORM\Column(length: 255)]
-    private ?string $resourceDisplayName = null;
+    private string $resourceDisplayName;
 
     #[Groups('userBookingCacheEntry')]
     #[ORM\Column(length: 255)]
-    private ?string $iCalUId = null;
+    private string $iCalUId;
 
-    public function getId(): ?int
+    public function getId(): int
     {
         return $this->id;
     }
 
-    public function getTitle(): ?string
+    public function getTitle(): string
     {
         return $this->title;
     }
@@ -144,7 +144,7 @@ class UserBookingCacheEntry
         return $this;
     }
 
-    public function getExchangeId(): ?string
+    public function getExchangeId(): string
     {
         return $this->exchangeId;
     }
@@ -156,7 +156,7 @@ class UserBookingCacheEntry
         return $this;
     }
 
-    public function getUid(): ?string
+    public function getUid(): string
     {
         return $this->uid;
     }
@@ -168,7 +168,7 @@ class UserBookingCacheEntry
         return $this;
     }
 
-    public function getStart(): ?\DateTimeInterface
+    public function getStart(): \DateTimeInterface
     {
         return $this->start;
     }
@@ -180,7 +180,7 @@ class UserBookingCacheEntry
         return $this;
     }
 
-    public function getEnd(): ?\DateTimeInterface
+    public function getEnd(): \DateTimeInterface
     {
         return $this->end;
     }
@@ -192,7 +192,7 @@ class UserBookingCacheEntry
         return $this;
     }
 
-    public function getStatus(): ?string
+    public function getStatus(): string
     {
         return $this->status;
     }
@@ -204,7 +204,7 @@ class UserBookingCacheEntry
         return $this;
     }
 
-    public function getResourceMail(): ?string
+    public function getResourceMail(): string
     {
         return $this->resourceMail;
     }
@@ -216,24 +216,24 @@ class UserBookingCacheEntry
         return $this;
     }
 
-    public function getResourceDisplayName(): ?string
+    public function getResourceDisplayName(): string
     {
         return $this->resourceDisplayName;
     }
 
-    public function setResourceDisplayName(?string $resourceDisplayName): static
+    public function setResourceDisplayName(string $resourceDisplayName): static
     {
         $this->resourceDisplayName = $resourceDisplayName;
 
         return $this;
     }
 
-    public function getICalUId(): ?string
+    public function getICalUId(): string
     {
         return $this->iCalUId;
     }
 
-    public function setICalUId(?string $iCalUId): static
+    public function setICalUId(string $iCalUId): static
     {
         $this->iCalUId = $iCalUId;
 

--- a/src/Entity/Main/UserBookingCacheEntry.php
+++ b/src/Entity/Main/UserBookingCacheEntry.php
@@ -89,7 +89,7 @@ class UserBookingCacheEntry
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
-    private int $id;
+    private ?int $id = null;
 
     #[Groups('userBookingCacheEntry')]
     #[ORM\Column(length: 255)]
@@ -127,7 +127,7 @@ class UserBookingCacheEntry
     #[ORM\Column(length: 255)]
     private string $iCalUId;
 
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/src/Service/MicrosoftGraphBookingService.php
+++ b/src/Service/MicrosoftGraphBookingService.php
@@ -604,6 +604,10 @@ class MicrosoftGraphBookingService implements BookingServiceInterface
     {
         $this->metricsHelper->incMethodTotal(__METHOD__, MetricsHelper::INVOKE);
 
+        if (empty($iCalUId)) {
+            throw new UserBookingException('Empty iCalUId is provided', 400);
+        }
+
         $token = $this->graphHelperService->authenticateAsServiceAccount();
 
         $path = "/me/events?\$filter=iCalUId eq '$iCalUId'";

--- a/tests/Controller/CancelBookingControllerTest.php
+++ b/tests/Controller/CancelBookingControllerTest.php
@@ -64,7 +64,7 @@ class CancelBookingControllerTest extends AbstractBaseApiTestCase
         $userBookingCacheServiceMock
             ->expects($this->exactly(1))
             ->method('deleteCacheEntryByICalUId')
-            ->with($mockBookingId1)
+            ->with($mockICalUid1)
         ;
 
         $container = self::getContainer();


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/dashboard/home#/tickets/showTicket/4050

#### Description

* Removed misleading null default from non-nullable properties
* Handles empty `iCalUId`
* Used iCalUId to delete cache entries

#### Screenshot of the result

N/A

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

N/A
